### PR TITLE
UF-6372: Added needed quotation marks to stringify filter map

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,6 @@ integration:
 logbook:
   exclusionfilters:
     # Exclude base64-encoded content from incoming requests.
-    json-path: {'$.bodyInformation.body' : '[base64]', '$.attachments[*].body': '[base64]'}
+    json-path: "{'$.bodyInformation.body' : '[base64]', '$.attachments[*].body': '[base64]'}"
     # Exclude base64-encoded content from traffic to/from skatteverket
-    x-path: {'//Body/text()':'[base64]', '//SignatureValue/text()':'[base64]', '//X509Certificate/text()':'[base64]'}
+    x-path: "{'//Body/text()':'[base64]', '//SignatureValue/text()':'[base64]', '//X509Certificate/text()':'[base64]'}"


### PR DESCRIPTION
- When using yaml as configuration format, exlusion filter paths needs to be surrounded by quotation marks to work