### PR TITLE
UF-6374 - Support-info relaxation

### DIFF
--- a/src/main/java/se/sundsvall/digitalmail/api/model/SupportInfo.java
+++ b/src/main/java/se/sundsvall/digitalmail/api/model/SupportInfo.java
@@ -17,15 +17,12 @@ public class SupportInfo {
     @Schema(description = "Information text describing the different ways the recipient may contact the sender.", example = "Kontakta oss via epost eller telefon.", requiredMode = REQUIRED)
     private String supportText;
     
-    @NotBlank
     @Schema(description = "Url where the recipient may find more information.", example = "https://sundsvall.se/")
     private String contactInformationUrl;
     
-    @NotBlank
     @Schema(description = "Phone number the recipient may call to get in contact with the sender.", example = "4660191000")
     private String contactInformationPhoneNumber;
     
-    @NotBlank
     @Schema(description = "Email address the recipient may use to get in contact with the sender.", example = "sundsvalls.kommun@sundsvall.se")
     private String contactInformationEmail;
 }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -456,9 +456,6 @@ components:
             description: Plain-text body
     SupportInfo:
       required:
-      - contactInformationEmail
-      - contactInformationPhoneNumber
-      - contactInformationUrl
       - supportText
       type: object
       properties:


### PR DESCRIPTION
Makes everything but "text" non-required in the support-info