### PR TITLE
UF-7340 - Expose invoice payable attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>se.sundsvall</groupId>
     <artifactId>api-service-digital-mail-sender</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
     <name>api-service-digital-mail-sender</name>
     <properties>
         <my-messages-generated-sources-folder>${project.build.directory}/my-messages-recipient-sources</my-messages-generated-sources-folder>

--- a/src/main/java/se/sundsvall/digitalmail/api/model/DigitalInvoiceRequest.java
+++ b/src/main/java/se/sundsvall/digitalmail/api/model/DigitalInvoiceRequest.java
@@ -36,6 +36,9 @@ public record DigitalInvoiceRequest(
         @Schema(description = "Invoice reference", example = "Faktura #12345")
         String reference,
 
+        @Schema(description = "Whether the invoice is payable", defaultValue = "true")
+        Boolean payable,
+
         @NotNull
         @Valid
         @Schema(requiredMode = REQUIRED)

--- a/src/main/java/se/sundsvall/digitalmail/integration/kivra/InvoiceDto.java
+++ b/src/main/java/se/sundsvall/digitalmail/integration/kivra/InvoiceDto.java
@@ -1,5 +1,7 @@
 package se.sundsvall.digitalmail.integration.kivra;
 
+import static java.util.Optional.ofNullable;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -19,6 +21,7 @@ public class InvoiceDto {
     private final InvoiceType type;
     private final String subject;
     private final String reference;
+    private final boolean payable;
     private final Float amount;
     private final LocalDate dueDate;
     private final ReferenceType paymentReferenceType;
@@ -34,6 +37,7 @@ public class InvoiceDto {
         type = invoiceRequest.type();
         subject = invoiceRequest.subject();
         reference = invoiceRequest.reference();
+        payable = ofNullable(invoiceRequest.payable()).orElse(true);
         amount = invoiceRequest.details().amount();
         dueDate = invoiceRequest.details().dueDate();
         paymentReferenceType = invoiceRequest.details().paymentReferenceType();

--- a/src/main/java/se/sundsvall/digitalmail/integration/kivra/KivraMapper.java
+++ b/src/main/java/se/sundsvall/digitalmail/integration/kivra/KivraMapper.java
@@ -1,6 +1,5 @@
 package se.sundsvall.digitalmail.integration.kivra;
 
-
 import static generated.com.kivra.PaymentMultipleOptions.CurrencyEnum.SEK;
 
 import java.time.format.DateTimeFormatter;
@@ -15,32 +14,31 @@ final class KivraMapper {
 
     static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    private KivraMapper() { }
+    private KivraMapper() {}
 
     static ContentUserV2 mapInvoiceToContent(final InvoiceDto invoiceDto) {
         return new ContentUserV2()
-          .ssn(invoiceDto.getSsn())
-          .subject(invoiceDto.getSubject())
-          .generatedAt(DATE_FORMATTER.format(invoiceDto.getGeneratedAt()))
-          .type(invoiceDto.getType().getValue())
-          .parts(invoiceDto.getFiles().stream()
-            .map(file -> new PartsResponsive()
-              .name(file.getFilename())
-              .contentType(file.getContentType())
-              .data(file.getBody())
-            )
-            .toList())
-          .paymentMultipleOptions(
-            new PaymentMultipleOptions()
-              .payable(true)
-              .currency(SEK)
-              .method(PaymentMultipleOptions.MethodEnum.fromValue(invoiceDto.getAccountType().getValue()))
-              .account(invoiceDto.getAccountNumber())
-              .options(List.of(new PaymentMultipleOptionsOptionsInner()
-                .dueDate(invoiceDto.getDueDate().toString())
-                .reference(invoiceDto.getPaymentReference())
-                .amount(invoiceDto.getAmount().toString())
-                .type(PaymentMultipleOptionsOptionsInner.TypeEnum.fromValue(invoiceDto.getPaymentReferenceType().name())))));
-
+            .ssn(invoiceDto.getSsn())
+            .subject(invoiceDto.getSubject())
+            .generatedAt(DATE_FORMATTER.format(invoiceDto.getGeneratedAt()))
+            .type(invoiceDto.getType().getValue())
+            .parts(invoiceDto.getFiles().stream()
+                .map(file -> new PartsResponsive()
+                    .name(file.getFilename())
+                    .contentType(file.getContentType())
+                    .data(file.getBody())
+                )
+                .toList())
+            .paymentMultipleOptions(
+                new PaymentMultipleOptions()
+                    .payable(invoiceDto.isPayable())
+                    .currency(SEK)
+                    .method(PaymentMultipleOptions.MethodEnum.fromValue(invoiceDto.getAccountType().getValue()))
+                    .account(invoiceDto.getAccountNumber())
+                    .options(List.of(new PaymentMultipleOptionsOptionsInner()
+                        .dueDate(invoiceDto.getDueDate().toString())
+                        .reference(invoiceDto.getPaymentReference())
+                        .amount(invoiceDto.getAmount().toString())
+                        .type(PaymentMultipleOptionsOptionsInner.TypeEnum.fromValue(invoiceDto.getPaymentReferenceType().name())))));
     }
 }

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -5,15 +5,15 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "2.1"
+  version: "2.2"
 servers:
-  - url: http://localhost:8080
-    description: Generated server url
+- url: http://localhost:8080
+  description: Generated server url
 paths:
   /send-digital-mail:
     post:
       tags:
-        - Digital Mail
+      - Digital Mail
       summary: Send a digital mail
       operationId: sendDigitalMail
       requestBody:
@@ -38,13 +38,13 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Problem'
-                  - $ref: '#/components/schemas/ConstraintViolationProblem'
+                - $ref: '#/components/schemas/Problem'
+                - $ref: '#/components/schemas/ConstraintViolationProblem'
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Problem'
-                  - $ref: '#/components/schemas/ConstraintViolationProblem'
+                - $ref: '#/components/schemas/Problem'
+                - $ref: '#/components/schemas/ConstraintViolationProblem'
         "404":
           description: Not Found
           content:
@@ -66,7 +66,7 @@ paths:
   /send-digital-invoice:
     post:
       tags:
-        - Digital Mail
+      - Digital Mail
       summary: Send a digital invoice
       operationId: sendDigitalInvoice
       requestBody:
@@ -91,13 +91,13 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Problem'
-                  - $ref: '#/components/schemas/ConstraintViolationProblem'
+                - $ref: '#/components/schemas/Problem'
+                - $ref: '#/components/schemas/ConstraintViolationProblem'
             application/problem+json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/Problem'
-                  - $ref: '#/components/schemas/ConstraintViolationProblem'
+                - $ref: '#/components/schemas/Problem'
+                - $ref: '#/components/schemas/ConstraintViolationProblem'
         "404":
           description: Not Found
           content:
@@ -119,16 +119,16 @@ paths:
   /has-available-mailbox/{partyId}:
     post:
       tags:
-        - Digital Mail
+      - Digital Mail
       summary: Check if a party has a digital mailbox and if said party has chosen
         to receive digital mail
       operationId: hasAvailableMailbox
       parameters:
-        - name: partyId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: partyId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: Successful Operation (available mailbox(es) found)
@@ -153,7 +153,7 @@ paths:
   /api-docs:
     get:
       tags:
-        - API
+      - API
       summary: OpenAPI
       operationId: getApiDocs
       responses:
@@ -171,30 +171,30 @@ components:
     Problem:
       type: object
       properties:
-        title:
-          type: string
-        detail:
-          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: object
         instance:
           type: string
           format: uri
         type:
           type: string
           format: uri
-        parameters:
-          type: object
-          additionalProperties:
-            type: object
+        title:
+          type: string
+        detail:
+          type: string
         status:
           $ref: '#/components/schemas/StatusType'
     StatusType:
       type: object
       properties:
-        reasonPhrase:
-          type: string
         statusCode:
           type: integer
           format: int32
+        reasonPhrase:
+          type: string
     ConstraintViolationProblem:
       type: object
       properties:
@@ -235,15 +235,15 @@ components:
           type: string
         message:
           type: string
-        detail:
-          type: string
-        instance:
-          type: string
-          format: uri
         parameters:
           type: object
           additionalProperties:
             type: object
+        instance:
+          type: string
+          format: uri
+        detail:
+          type: string
         suppressed:
           type: array
           items:
@@ -306,20 +306,20 @@ components:
                 type: boolean
         message:
           type: string
-        title:
-          type: string
-        detail:
-          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: object
         instance:
           type: string
           format: uri
         type:
           type: string
           format: uri
-        parameters:
-          type: object
-          additionalProperties:
-            type: object
+        title:
+          type: string
+        detail:
+          type: string
         status:
           $ref: '#/components/schemas/StatusType'
         suppressed:
@@ -364,9 +364,9 @@ components:
           type: string
     Attachment:
       required:
-        - body
-        - contentType
-        - filename
+      - body
+      - contentType
+      - filename
       type: object
       properties:
         contentType:
@@ -383,7 +383,7 @@ components:
       description: A PDF file/attachment
     BodyInformation:
       required:
-        - contentType
+      - contentType
       type: object
       properties:
         contentType:
@@ -397,10 +397,10 @@ components:
       description: The body of the message
     DigitalMailRequest:
       required:
-        - headerSubject
-        - municipalityId
-        - partyId
-        - supportInfo
+      - headerSubject
+      - municipalityId
+      - partyId
+      - supportInfo
       type: object
       properties:
         partyId:
@@ -427,7 +427,7 @@ components:
       description: The body of the digital mail request
     SupportInfo:
       required:
-        - supportText
+      - supportText
       type: object
       properties:
         supportText:
@@ -467,12 +467,12 @@ components:
           $ref: '#/components/schemas/DeliveryStatus'
     Details:
       required:
-        - accountNumber
-        - accountType
-        - amount
-        - dueDate
-        - paymentReference
-        - paymentReferenceType
+      - accountNumber
+      - accountType
+      - amount
+      - dueDate
+      - paymentReference
+      - paymentReferenceType
       type: object
       properties:
         amount:
@@ -490,8 +490,8 @@ components:
           description: The payment reference type
           example: SE_OCR
           enum:
-            - SE_OCR
-            - TENANT_REF
+          - SE_OCR
+          - TENANT_REF
         paymentReference:
           maxLength: 25
           type: string
@@ -502,8 +502,8 @@ components:
           description: The receiving account type
           example: BANKGIRO
           enum:
-            - BANKGIRO
-            - PLUSGIRO
+          - BANKGIRO
+          - PLUSGIRO
         accountNumber:
           type: string
           description: The receiving account (a valid BANKGIRO or PLUSGIRO number)
@@ -511,11 +511,11 @@ components:
       description: Invoice details
     DigitalInvoiceRequest:
       required:
-        - details
-        - files
-        - partyId
-        - subject
-        - type
+      - details
+      - files
+      - partyId
+      - subject
+      - type
       type: object
       properties:
         partyId:
@@ -527,10 +527,10 @@ components:
           type: string
           description: Invoice type
           example: INVOICE
-          enum:
-            - INVOICE
-            - REMINDER
           default: INVOICE
+          enum:
+          - INVOICE
+          - REMINDER
         subject:
           type: string
           description: The invoice subject
@@ -539,6 +539,10 @@ components:
           type: string
           description: Invoice reference
           example: "Faktura #12345"
+        payable:
+          type: boolean
+          description: Whether the invoice is payable
+          default: true
         details:
           $ref: '#/components/schemas/Details'
         files:

--- a/src/test/java/se/sundsvall/digitalmail/TestObjectFactory.java
+++ b/src/test/java/se/sundsvall/digitalmail/TestObjectFactory.java
@@ -59,6 +59,7 @@ public final class TestObjectFactory {
             INVOICE,
             "someSubject",
             "someReference",
+            true,
             new DigitalInvoiceRequest.Details(
                 123.45f,
                 LocalDate.now(),

--- a/src/test/java/se/sundsvall/digitalmail/api/model/DigitalInvoiceRequestTests.java
+++ b/src/test/java/se/sundsvall/digitalmail/api/model/DigitalInvoiceRequestTests.java
@@ -30,12 +30,13 @@ class DigitalInvoiceRequestTests {
         final var file = new File(contentType, body, filename);
 
         final var request = new DigitalInvoiceRequest(partyId, type, subject,
-            reference, details, List.of(file));
+            reference, true, details, List.of(file));
 
         assertThat(request.partyId()).isEqualTo(partyId);
         assertThat(request.type()).isEqualTo(type);
         assertThat(request.subject()).isEqualTo(subject);
         assertThat(request.reference()).isEqualTo(reference);
+        assertThat(request.payable()).isTrue();
         assertThat(request.details()).isEqualTo(details);
         assertThat(request.files()).hasSize(1).satisfies(files -> {
             assertThat(file.getContentType()).isEqualTo(contentType);

--- a/src/test/java/se/sundsvall/digitalmail/integration/kivra/KivraMapperTests.java
+++ b/src/test/java/se/sundsvall/digitalmail/integration/kivra/KivraMapperTests.java
@@ -26,15 +26,14 @@ class KivraMapperTests {
         assertThat(content.getType()).isEqualTo(invoiceDto.getType().getValue());
         assertThat(content.getParts()).hasSameSizeAs(invoiceDto.getFiles());
         assertThat(content.getPaymentMultipleOptions()).isInstanceOfSatisfying(PaymentMultipleOptions.class, payment -> {
-                assertThat(payment.getPayable()).isTrue();
-                assertThat(payment.getCurrency()).isEqualTo(PaymentMultipleOptions.CurrencyEnum.SEK);
-                assertThat(payment.getOptions().getFirst().getDueDate()).isEqualTo(invoiceDto.getDueDate().format(DATE_FORMATTER));
-                assertThat(payment.getOptions().getFirst().getAmount()).isEqualTo(invoiceDto.getAmount().toString());
-                assertThat(payment.getOptions().getFirst().getType()).isEqualTo(PaymentMultipleOptionsOptionsInner.TypeEnum.fromValue(invoiceDto.getPaymentReferenceType().name()));
-                assertThat(payment.getMethod()).isEqualTo(PaymentMultipleOptions.MethodEnum.fromValue(invoiceDto.getAccountType().getValue()));
-                assertThat(payment.getAccount()).isEqualTo(invoiceDto.getAccountNumber());
-                assertThat(payment.getOptions().getFirst().getReference()).isEqualTo(invoiceDto.getPaymentReference());
-            });
-
+            assertThat(payment.getPayable()).isTrue();
+            assertThat(payment.getCurrency()).isEqualTo(PaymentMultipleOptions.CurrencyEnum.SEK);
+            assertThat(payment.getOptions().getFirst().getDueDate()).isEqualTo(invoiceDto.getDueDate().format(DATE_FORMATTER));
+            assertThat(payment.getOptions().getFirst().getAmount()).isEqualTo(invoiceDto.getAmount().toString());
+            assertThat(payment.getOptions().getFirst().getType()).isEqualTo(PaymentMultipleOptionsOptionsInner.TypeEnum.fromValue(invoiceDto.getPaymentReferenceType().name()));
+            assertThat(payment.getMethod()).isEqualTo(PaymentMultipleOptions.MethodEnum.fromValue(invoiceDto.getAccountType().getValue()));
+            assertThat(payment.getAccount()).isEqualTo(invoiceDto.getAccountNumber());
+            assertThat(payment.getOptions().getFirst().getReference()).isEqualTo(invoiceDto.getPaymentReference());
+        });
     }
 }


### PR DESCRIPTION
Exposes the `payable` attribute for invoices, with a default value of `true` if omitted. This change is mainly for sending "autogiro" invoices that are already set up for automatic payment and shouldn't be possible to pay again.